### PR TITLE
Extend functionality to allow for multiple inline color functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,49 @@
 Bash colors
 ===========
 
-The library defines verbal constants for ANSII color codes.  
+The library defines verbal constants for ANSII color codes.
 Now you can use words to tell bash what color you want to use for output.
 
-Also, it defines functions to quickly output colored text.  
+Also, it defines functions to quickly output colored text.
 As well as a function to display nice table of all colors.
+
+Updated to allow for iterative output of colors by sequencing the color functions
 
 
 Examples
 --------
 
-Print "foobar" with red foreground.  
+Print "foobar" with red foreground:
 ```sh
 $ clr_red "foobar"
 ```
 
-Print "foobar" with green background.  
+Print "foobar" with green background:
 ```sh
 $ clr_greenb "foobar"
 ```
 
-Print "foobar" with cyan foreground and bold font.  
+Print "foobar" with cyan foreground and bold font:
 ```sh
-$ clr_bold "$(clr_cyan foobar)"
+$ clr_bold clr_cyan "foobar"
 ```
 
-or manually, using variables  
+Stack functions on a single output to produce complex color configurations:
+```sh
+$ clr_red clr_blueb clr_reverse clr_underscore "foobar"
+```
+
+Using the -n switch, the output can remain on a single line, allowing for changing colors across a line of text:
+```sh
+$ clr_redb clr_black "RED" -n; clr_blueb clr_black "BLUE" -n; clr_greenb clr_black "GREEN";
+```
+
+or Print "foobar" manually, using variables:
 ```sh
 $ clr_escape "foobar" $CLR_BOLD $CLR_CYAN
 ```
 
-or any other code  
+or any other code:
 ```sh
 $ clr_escape "foobar" 1 36
 ```
@@ -40,7 +52,7 @@ $ clr_escape "foobar" 1 36
 Quick start
 ------------
 
-1. Download source  
+1. Download source
 ```sh
 $ curl https://raw.github.com/maxtsepkov/bash_colors/master/bash_colors.sh > .bash_colors
 ```
@@ -54,34 +66,40 @@ $ source .bash_colors
 Variables
 ---------
 
-**$CLR_***  
-  
-Variables for each supported color code. E.g. $CLR_WHITE, $CLR_BLACK  
+**$CLR_***
+
+Variables for each supported color code. E.g. $CLR_WHITE, $CLR_BLACK
 Call **clr_dump** for full list.
 
-**$CLR_ESC**  
+**$CLR_ESC**
 is a special variable for escape code (\033) followed by [ character.
 
 
 Functions
 ---------
 
-**clr_dump**  
+**clr_dump**
 Output table of available colors, functions and variables.
 
-**clr_*** _string_  
-Functions for each supported color. E.g. clr_white, clr_black  
+**clr_*** _string_
+Functions for each supported color. E.g. clr_white, clr_black
 See **clr_dump** for list.
 
-**clr_escape** _string_ _$CLR_ ...  
+**fn_exists**
+General bash function to check if string is a valid function
+
+**clr_layer**
+Recursive function allowing for muliple color functions in a sequence
+
+**clr_escape** _string_ _$CLR_ ...
 escape _string_ with given colors. Latest colors overwrites previous.
 
-**clr_reset**  
+**clr_reset**
 Reset formatting. Useful for custom usage of $CLR_* variable series.
 
 
 See also
 --------
 
-console_codes(4)  
+console_codes(4)
 [Advanced Bash Scripting Guide](http://tldp.org/LDP/abs/html/colorizing.html)

--- a/bash_colors.sh
+++ b/bash_colors.sh
@@ -36,6 +36,55 @@ CLR_MAGENTAB=45         # set magenta background
 CLR_CYANB=46            # set cyan background
 CLR_WHITEB=47           # set white background
 
+
+# check if string exists as function
+# usage: if fn_exists "sometext"; then ... fi
+function fn_exists
+{
+    type -t "$1" | grep -q 'function'
+}
+
+# iterate through command arguments, o allow for iterative color application
+function clr_layer
+{
+    # default echo setting
+    CLR_ECHOSWITCHES="-e"
+    CLR_STACK=""
+    CLR_SWITCHES=""
+    ARGS=("$@")
+
+    # iterate over arguments in reverse
+    for ((i=$#; i>=0; i--)); do
+        ARG=${ARGS[$i]}
+        # echo $ARG
+        # set CLR_VAR as last argtype
+        firstletter=${ARG:0:1}
+
+        # check if argument is a switch
+        if [ "$firstletter" = "-" ] ; then
+            # if -n is passed, set switch for echo in clr_escape
+            if [[ $ARG == *"n"* ]]; then
+                CLR_ECHOSWITCHES="-en"
+                CLR_SWITCHES=$ARG
+            fi
+        else
+            # last arg is the incoming string
+            if [ -z "$CLR_STACK" ]; then
+                CLR_STACK=$ARG
+            else
+                # if the argument is function, apply it
+                if [ -n "$ARG" ] && fn_exists $ARG; then
+                    #continue to pass switches through recursion
+                    CLR_STACK=$($ARG "$CLR_STACK" $CLR_SWITCHES)
+                fi
+            fi
+        fi
+    done
+
+    # pass stack and color var to escape function
+    clr_escape "$CLR_STACK" $1;
+}
+
 # General function to wrap string with escape sequence(s).
 # Ex: clr_escape foobar $CLR_RED $CLR_BOLD
 function clr_escape
@@ -49,34 +98,34 @@ function clr_escape
 	shift || break
     done
 
-    echo -e "$result"
+    echo "$CLR_ECHOSWITCHES" "$result"
 }
 
-function clr_reset           { clr_escape "$1" $CLR_RESET;           }
-function clr_reset_underline { clr_escape "$1" $CLR_RESET_UNDERLINE; }
-function clr_reset_reverse   { clr_escape "$1" $CLR_RESET_REVERSE;   }
-function clr_default         { clr_escape "$1" $CLR_DEFAULT;         }
-function clr_defaultb        { clr_escape "$1" $CLR_DEFAULTB;        }
-function clr_bold            { clr_escape "$1" $CLR_BOLD;            }
-function clr_bright          { clr_escape "$1" $CLR_BRIGHT;          }
-function clr_underscore      { clr_escape "$1" $CLR_UNDERSCORE;      }
-function clr_reverse         { clr_escape "$1" $CLR_REVERSE;         }
-function clr_black           { clr_escape "$1" $CLR_BLANK;           }
-function clr_red             { clr_escape "$1" $CLR_RED;             }
-function clr_green           { clr_escape "$1" $CLR_GREEN;           }
-function clr_brown           { clr_escape "$1" $CLR_BROWN;           }
-function clr_blue            { clr_escape "$1" $CLR_BLUE;            }
-function clr_magenta         { clr_escape "$1" $CLR_MAGENTA;         }
-function clr_cyan            { clr_escape "$1" $CLR_CYAN;            }
-function clr_white           { clr_escape "$1" $CLR_WHITE;           }
-function clr_blackb          { clr_escape "$1" $CLR_BLACKB;          }
-function clr_redb            { clr_escape "$1" $CLR_REDB;            }
-function clr_greenb          { clr_escape "$1" $CLR_GREENB;          }
-function clr_brownb          { clr_escape "$1" $CLR_BROWNB;          }
-function clr_blueb           { clr_escape "$1" $CLR_BLUEB;           }
-function clr_magentab        { clr_escape "$1" $CLR_MAGENTAB;        }
-function clr_cyanb           { clr_escape "$1" $CLR_CYANB;           }
-function clr_whiteb          { clr_escape "$1" $CLR_WHITEB;          }
+function clr_reset           { clr_layer $CLR_RESET "$@";           }
+function clr_reset_underline { clr_layer $CLR_RESET_UNDERLINE "$@"; }
+function clr_reset_reverse   { clr_layer $CLR_RESET_REVERSE "$@";   }
+function clr_default         { clr_layer $CLR_DEFAULT "$@";         }
+function clr_defaultb        { clr_layer $CLR_DEFAULTB "$@";        }
+function clr_bold            { clr_layer $CLR_BOLD "$@";            }
+function clr_bright          { clr_layer $CLR_BRIGHT "$@";          }
+function clr_underscore      { clr_layer $CLR_UNDERSCORE "$@";      }
+function clr_reverse         { clr_layer $CLR_REVERSE "$@";         }
+function clr_black           { clr_layer $CLR_BLACK "$@";           }
+function clr_red             { clr_layer $CLR_RED "$@";             }
+function clr_green           { clr_layer $CLR_GREEN "$@";           }
+function clr_brown           { clr_layer $CLR_BROWN "$@";           }
+function clr_blue            { clr_layer $CLR_BLUE "$@";            }
+function clr_magenta         { clr_layer $CLR_MAGENTA "$@";         }
+function clr_cyan            { clr_layer $CLR_CYAN "$@";            }
+function clr_white           { clr_layer $CLR_WHITE "$@";           }
+function clr_blackb          { clr_layer $CLR_BLACKB "$@";          }
+function clr_redb            { clr_layer $CLR_REDB "$@";            }
+function clr_greenb          { clr_layer $CLR_GREENB "$@";          }
+function clr_brownb          { clr_layer $CLR_BROWNB "$@";          }
+function clr_blueb           { clr_layer $CLR_BLUEB "$@";           }
+function clr_magentab        { clr_layer $CLR_MAGENTAB "$@";        }
+function clr_cyanb           { clr_layer $CLR_CYANB "$@";           }
+function clr_whiteb          { clr_layer $CLR_WHITEB "$@";          }
 
 # Outputs colors table
 function clr_dump


### PR DESCRIPTION
- add recursive functionality for multiple inline color functions, simplifying the syntax when using multiple modifiers
- include a switch (-n) to allow output to stay on one line, using the echo -n option
- fixed a typo where black as typed as blank
- readme updated accordingly