### PR TITLE
only escapes "-n", prints other strings starting with a dash as expected

### DIFF
--- a/bash_colors.sh
+++ b/bash_colors.sh
@@ -61,12 +61,10 @@ function clr_layer
         firstletter=${ARG:0:1}
 
         # check if argument is a switch
-        if [ "$firstletter" = "-" ] ; then
             # if -n is passed, set switch for echo in clr_escape
-            if [[ $ARG == *"n"* ]]; then
-                CLR_ECHOSWITCHES="-en"
-                CLR_SWITCHES=$ARG
-            fi
+        if [[ ("$firstletter" = "-") && ($ARG == *"n"*) ]]; then
+            CLR_ECHOSWITCHES="-en"
+            CLR_SWITCHES=$ARG
         else
             # last arg is the incoming string
             if [ -z "$CLR_STACK" ]; then


### PR DESCRIPTION
#!/usr/bin/env bash

. bash_colors.sh
clr_blue -n "9"
clr_red -n "-"
clr_green -n "5"
clr_magenta -n "="
clr_cyan "4"

echo "Usage: $(clr_bold -n '--help')"